### PR TITLE
ci: release-plz のカイゼン

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -114,6 +114,32 @@ jobs:
             manifest["."] = newVersion;
             const newContent = Buffer.from(JSON.stringify(manifest, null, 2)).toString('base64');
 
+            // パッケージJSONの更新
+            const packageJsonPath = 'package.json';
+            if (fs.existsSync(packageJsonPath)) {
+              const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+              const packageJson = JSON.parse(packageJsonContent);
+              packageJson.version = newVersion;
+              const newPackageJsonContent = Buffer.from(JSON.stringify(packageJson, null, 2)).toString('base64');
+              
+              // Get the current SHA of package.json
+              const { data: packageJsonFile } = await github.rest.repos.getContent({
+                ...context.repo,
+                path: packageJsonPath,
+                ref: branchName,
+              });
+
+              // Update package.json
+              await github.rest.repos.createOrUpdateFileContents({
+                ...context.repo,
+                path: packageJsonPath,
+                message: `chore: update package.json version to ${newVersion}`,
+                content: newPackageJsonContent,
+                sha: packageJsonFile.sha,
+                branch: branchName,
+              });
+            }
+
             // Get the current SHA of the file
             const { data: file } = await github.rest.repos.getContent({
               ...context.repo,
@@ -208,6 +234,32 @@ jobs:
             const manifest = JSON.parse(content);
             manifest["."] = newVersion;
             const newContent = Buffer.from(JSON.stringify(manifest, null, 2)).toString('base64');
+
+            // パッケージJSONの更新
+            const packageJsonPath = 'package.json';
+            if (fs.existsSync(packageJsonPath)) {
+              const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+              const packageJson = JSON.parse(packageJsonContent);
+              packageJson.version = newVersion;
+              const newPackageJsonContent = Buffer.from(JSON.stringify(packageJson, null, 2)).toString('base64');
+              
+              // Get the current SHA of package.json
+              const { data: packageJsonFile } = await github.rest.repos.getContent({
+                ...context.repo,
+                path: packageJsonPath,
+                ref: branchName,
+              });
+
+              // Update package.json
+              await github.rest.repos.createOrUpdateFileContents({
+                ...context.repo,
+                path: packageJsonPath,
+                message: `chore: update package.json version to ${newVersion}`,
+                content: newPackageJsonContent,
+                sha: packageJsonFile.sha,
+                branch: branchName,
+              });
+            }
 
             // Get the current SHA of the file after reset
             const { data: file } = await github.rest.repos.getContent({

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -140,6 +140,13 @@ jobs:
               body: `${{ steps.generate_notes.outputs.result }}`,
             });
 
+            // ラベルを追加
+            await github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: pr.data.number,
+              labels: ['ignore for release']
+            });
+
             return pr.data.html_url;
 
       - name: Display PR URL


### PR DESCRIPTION
## Issue

- close #なし 🦕

## 概要

release-plz.yml ワークフローに以下の機能を追加：

1. package.json のバージョン自動更新
   - リリース時に package.json のバージョンを新しいバージョンに更新
   - 更新内容を別コミットとして作成

2. PRラベルの自動付与
   - 作成されたPRに `ignore for release` ラベルを自動で追加

## レビュー観点

- package.json のバージョン更新処理が正しく動作すること
- `ignore for release` ラベルが正しく付与されること
- GitHub API の使用方法が適切であること

## レビューレベル

- [x] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する

## レビュー優先度

- [x] 今日〜明日中で見てもらいたい 🚶

## 参考リンク

- [GitHub REST API - Repos](https://docs.github.com/en/rest/repos)
- [GitHub REST API - Issues](https://docs.github.com/en/rest/issues)

## スクリーンショット

該当なし（ワークフローの変更のため）
